### PR TITLE
fix_.vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
 		{
 			"label": "start",
 			"type": "shell",
-			"command": "npm run electron:serve",
+			"command": "cd study_book_client & npm run electron:serve",
 			"group": {
 				"kind": "build",
 				"isDefault": true


### PR DESCRIPTION
VSCodeでタスクが正常に動かないエラーを修正
カレントディレクトリをタスク実行直前に変えるという場当たり的な処置の為、後で変更が必要になるかも